### PR TITLE
Fixed an issue with `bind-with`...

### DIFF
--- a/woodhouse.js
+++ b/woodhouse.js
@@ -1365,7 +1365,7 @@
           this.removeBindings(childBindings);
 
           childBindings = childBindings.concat(this.addBindings({
-            el: $bindEl,
+            el: $bindEl.children(),
             model: context,
             keypathPrefix: keypathPrefix
           }));


### PR DESCRIPTION
Fixed an issue with `bind-with` where it would re-bind itself. 

For example:

```
<a href=“#” bind-click=“onClick” bind-with=“someContext”>…</a>
```

would cause `onClick` to be called twice.

Solution:
Changed logic so that `bind-with` will only affect child elements.
