### PR TITLE
Use caret ranges for dependencies since they are all >1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,9 +13,9 @@
     "*.ico"
   ],
   "dependencies": {
-    "backbone": "1.1.2",
-    "lodash": "3.6.0",
-    "jquery": "1.11.2"
+    "backbone": "^1.1.2",
+    "lodash": "^3.6.0",
+    "jquery": "^1.11.2"
   },
   "homepage": "https://github.com/airbrite/woodhouse.git",
   "devDependencies": {


### PR DESCRIPTION
Having absolute dependency versions makes it difficult to use
Woodhouse as a dependency.